### PR TITLE
remove more-itertools from requirements

### DIFF
--- a/cassandra/timeseries_utils.py
+++ b/cassandra/timeseries_utils.py
@@ -1,5 +1,5 @@
 import numpy as np
-from more_itertools import windowed
+from .utils import windowed
 
 
 def sliding_window(data, window_size: int):

--- a/cassandra/utils.py
+++ b/cassandra/utils.py
@@ -1,5 +1,56 @@
+from collections import deque
+from itertools import (
+    chain,
+    repeat,
+)
 from pathlib import Path
 
 
 def get_asset_filepath(filename):
     return Path(__file__).parent / "assets" / filename
+
+# https://github.com/more-itertools/more-itertools/blob/master/more_itertools/more.py
+def windowed(seq, n, fillvalue=None, step=1):
+    """Return a sliding window of width *n* over the given iterable.
+        >>> all_windows = windowed([1, 2, 3, 4, 5], 3)
+        >>> list(all_windows)
+        [(1, 2, 3), (2, 3, 4), (3, 4, 5)]
+    When the window is larger than the iterable, *fillvalue* is used in place
+    of missing values:
+        >>> list(windowed([1, 2, 3], 4))
+        [(1, 2, 3, None)]
+    Each window will advance in increments of *step*:
+        >>> list(windowed([1, 2, 3, 4, 5, 6], 3, fillvalue='!', step=2))
+        [(1, 2, 3), (3, 4, 5), (5, 6, '!')]
+    To slide into the iterable's items, use :func:`chain` to add filler items
+    to the left:
+        >>> iterable = [1, 2, 3, 4]
+        >>> n = 3
+        >>> padding = [None] * (n - 1)
+        >>> list(windowed(chain(padding, iterable), 3))
+        [(None, None, 1), (None, 1, 2), (1, 2, 3), (2, 3, 4)]
+    """
+    if n < 0:
+        raise ValueError("n must be >= 0")
+    if n == 0:
+        yield tuple()
+        return
+    if step < 1:
+        raise ValueError("step must be >= 1")
+
+    window = deque(maxlen=n)
+    i = n
+    for _ in map(window.append, seq):
+        i -= 1
+        if not i:
+            i = step
+            yield tuple(window)
+
+    size = len(window)
+    if size == 0:
+        return
+    elif size < n:
+        yield tuple(chain(window, repeat(fillvalue, n - size)))
+    elif 0 < i < min(step, n):
+        window += (fillvalue,) * i
+        yield tuple(window)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 yfinance
 pandas
 numpy
-more-itertools
 holidays
 # dashboard
 plotly
@@ -10,6 +9,7 @@ dash
 dash-renderer 
 dash-core-components
 dash-html-components 
+# deployment
 gunicorn
 # inference
 scikit-learn==1.0.2


### PR DESCRIPTION
So that the app doesn't exceed Heroku slug size limit, which is 500 MB